### PR TITLE
docs: Configure Korean language support and add English locale

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -19,18 +19,23 @@ import { transformHead } from './scripts/transformHead'
 import { teamMembers } from './contributors'
 
 export default withPwa(defineConfig({
-  lang: 'en-US',
+  lang: 'ko-KR',
   title: vitestName,
   description: vitestDescription,
   locales: {
     root: {
-      label: 'English',
-      lang: 'en-US',
+      label: '한국어',
+      lang: 'ko-KR',
     },
     zh: {
       label: '简体中文',
       lang: 'zh',
       link: 'https://cn.vitest.dev/',
+    },
+    en: {
+      label: 'English',
+      lang: 'en',
+      link: 'https://vitest.dev/',
     },
   },
   head: [

--- a/docs/.vitepress/meta.ts
+++ b/docs/.vitepress/meta.ts
@@ -3,7 +3,7 @@
 /* Texts */
 export const vitestName = 'Vitest'
 export const vitestShortName = 'Vitest'
-export const vitestDescription = 'Next generation testing framework powered by Vite'
+export const vitestDescription = '차세대 테스트 프레임워크'
 
 /* CDN fonts and styles */
 export const googleapis = 'https://fonts.googleapis.com'
@@ -11,7 +11,7 @@ export const gstatic = 'https://fonts.gstatic.com'
 export const font = `${googleapis}/css2?family=Readex+Pro:wght@200;400;600&display=swap`
 
 /* vitepress head */
-export const ogUrl = 'https://vitest.dev/'
+export const ogUrl = 'https://ko.vitest.dev/'
 export const ogImage = `${ogUrl}og.png`
 
 /* GitHub and social links */

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,12 +3,12 @@ layout: home
 sidebar: false
 
 title: Vitest
-titleTemplate: Next Generation testing framework
+titleTemplate: 차세대 테스트 프레임워크
 
 hero:
   name: Vitest
-  text: Next Generation Testing Framework
-  tagline: A Vite-native testing framework. It's fast!
+  text: 차세대 테스트 프레임워크
+  tagline: Vite 기반 테스트 프레임워크. 매우 빠릅니다!
   image:
     src: /logo-shadow.svg
     alt: Vitest
@@ -27,16 +27,16 @@ hero:
       link: https://github.com/vitest-dev/vitest
 
 features:
-  - title: Vite Powered
+  - title: Vite 구동
     icon: <span class="i-logos:vitejs"></span>
-    details: Reuse Vite's config and plugins - consistent across your app and tests. But it's not required to use Vitest!
-  - title: Jest Compatible
+    details: Vite 구성과 플러그인을 재사용이 가능해요. 앱과 테스트 전반에 걸쳐 일관성을 보장합니다. 하지만 반드시 Vitest를 사용해야 하는 것은 아닙니다!
+  - title: Jest 호환성
     icon: <span class="i-logos:jest"></span>
-    details: Expect, snapshot, coverage, and more - migrating from Jest is straightforward.
-  - title: Smart & instant watch mode
+    details: Expect, snapshot, coverage Jest에서 마이그레이션이 간단해요.
+  - title: 스마트하고 즉각적인 watch 모드
     icon: ⚡
-    details: Only rerun the related changes, just like HMR for tests!
+    details: 테스트용 HMR과 마찬가지로 변경 사항만 재실행이 가능해요!
   - title: ESM, TypeScript, JSX
     icon: <span class="i-logos:typescript-icon"></span>
-    details: Out-of-box ESM, TypeScript and JSX support powered by esbuild.
+    details: JavaScript 모듈을 번들링 없이 바로 사용할 수 있는 ESM, esbuild로 구동되는 TypeScript 및 JSX 지원해요.
 ---


### PR DESCRIPTION
Body:
- Updated docs`/.vitepress/config.ts` to set the default language to Korean (ko-KR).
- Configured locales for English (en) and Korean (ko-KR).
- Adjusted the root locale label and language code.
- Updated docs`/.vitepress/meta.ts` with Korean descriptions and URLs.

Reason:
- Enhance multilingual support for the documentation website, catering to Korean and English audiences.